### PR TITLE
RNG module as single thread-safe implementation, but with manual instantiation available.

### DIFF
--- a/src/GopherWoodEngine.Runtime/EngineConfig.cs
+++ b/src/GopherWoodEngine.Runtime/EngineConfig.cs
@@ -10,25 +10,24 @@ public record EngineConfig
     /// <summary>
     /// The display name of the game.
     /// </summary>
-    public required string Title { get; set; }
+    public required string Title { get; init; }
 
     /// <summary>
     /// Design width of the game window, in pixels.
     /// </summary>
-    public int Width { get; set; } = 1280;
+    public int Width { get; init; } = 1280;
 
     /// <summary>
     /// Design height of the game window, in pixels.
     /// </summary>
-    public int Height { get; set; } = 720;
+    public int Height { get; init; } = 720;
 
     /// <summary>
-    /// Gets or sets the seed value used to initialize a deterministic random number generator.
+    /// Optional seed value for initializing the shared application <see cref="IRandomNumberGenerator"/> singleton service.
     /// </summary>
     /// <remarks>
-    /// If the value is null, a default seed is used.
-    /// To use the deterministic random number generator in your game systems,
-    /// inject <see cref="IRandomNumberGenerator"/> with <c>[FromKeyedServices("Deterministic")]</c> attribute.
+    /// When set to a specific value, enables reproducible random number generation for debugging, testing, or replay functionality.
+    /// When <c>null</c>, random number generation is non-deterministic.
     /// </remarks>
-    public int? RandomSeed { get; set; } = null;
+    public int? RandomSeed { get; init; } = null;
 }

--- a/src/GopherWoodEngine.Runtime/Modules/CoreSystems/ModuleOrchastration/DependencyInjection.cs
+++ b/src/GopherWoodEngine.Runtime/Modules/CoreSystems/ModuleOrchastration/DependencyInjection.cs
@@ -8,9 +8,7 @@ internal static class DependencyInjection
     {
         // Core Systems
         services.AddEngineLogging();
-        services.AddKeyedSingleton<IRandomNumberGenerator, RandomNumberGenerator>("ThreadSafe", (sp, key) => new RandomNumberGenerator(seed: null));
-        services.AddKeyedSingleton<IRandomNumberGenerator, RandomNumberGenerator>("Deterministic", (sp, key) => new RandomNumberGenerator(seed: engineConfig.RandomSeed ?? 0));
-        services.AddSingleton(sp => sp.GetRequiredKeyedService<IRandomNumberGenerator>("ThreadSafe")); // Register default (non-keyed), resolves to ThreadSafe by default.
+        services.AddSingleton<IRandomNumberGenerator>(new RandomNumberGenerator(seed: engineConfig.RandomSeed));
 
         // Gameplay Foundations
         services.AddSingleton<IEventSystem, EventSystem>();

--- a/src/GopherWoodEngine.Runtime/Modules/CoreSystems/RNG/RandomNumberGenerator.cs
+++ b/src/GopherWoodEngine.Runtime/Modules/CoreSystems/RNG/RandomNumberGenerator.cs
@@ -1,61 +1,198 @@
 ﻿using System;
+using System.Threading;
 
 namespace GopherWoodEngine.Runtime.Modules;
 
-internal sealed class RandomNumberGenerator : IRandomNumberGenerator
+/// <summary>
+/// Provides a thread-safe implementation of <see cref="IRandomNumberGenerator"/> that wraps <see cref="Random"/>.
+/// </summary>
+/// <remarks>
+/// All methods are protected by a lock to ensure thread-safety when the instance is shared across multiple threads.
+/// Each instance maintains its own independent random number sequence.
+/// </remarks>
+public sealed class RandomNumberGenerator : IRandomNumberGenerator
 {
     private readonly Random _random;
+    private readonly Lock _lock;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="RandomNumberGenerator"/> class.
     /// </summary>
     /// <param name="seed">
     /// An optional seed value to initialize the random number generator.
-    /// If <c>null</c>, creates a thread-safe shared instance.
-    /// If provided, creates an instance with the specified seed for reproducible results, but for single-threaded contexts only.
+    /// If <c>null</c>, the generator is initialized with a time-dependent default seed.
+    /// If provided, creates a deterministic sequence for reproducible results.
     /// </param>
     /// <remarks>
-    /// Use seeded instances in single-threaded contexts (like deterministic game logic on the main thread).
-    /// Use seed: <c>null</c> when you need thread-safety for concurrent operations.
+    /// This implementation is thread-safe and can be safely shared across multiple threads.
+    /// Use a specific seed for deterministic behavior (e.g., in replays, networked games, or unit tests).
+    /// Use <c>null</c> for non-deterministic randomness.
     /// </remarks>
     public RandomNumberGenerator(int? seed = null)
     {
-        _random = seed != null ? new Random(seed.Value) : Random.Shared;
+        _random = seed.HasValue ? new Random(seed.Value) : new Random();
+        _lock = new Lock();
     }
 
-    public string GetHexString(int stringLength, bool lowercase = false) => _random.GetHexString(stringLength, lowercase);
+    /// <inheritdoc/>
+    public string GetHexString(int stringLength, bool lowercase = false)
+    {
+        lock (_lock)
+        {
+            return _random.GetHexString(stringLength, lowercase);
+        }
+    }
 
-    public void GetHexString(Span<char> destination, bool lowercase = false) => _random.GetHexString(destination, lowercase);
+    /// <inheritdoc/>
+    public void GetHexString(Span<char> destination, bool lowercase = false)
+    {
+        lock (_lock)
+        {
+            _random.GetHexString(destination, lowercase);
+        }
+    }
 
-    public void GetItems<T>(ReadOnlySpan<T> choices, Span<T> destination) => _random.GetItems<T>(choices, destination);
+    /// <inheritdoc/>
+    public void GetItems<T>(ReadOnlySpan<T> choices, Span<T> destination)
+    {
+        lock (_lock)
+        {
+            _random.GetItems<T>(choices, destination);
+        }
+    }
 
-    public T[] GetItems<T>(T[] choices, int length) => _random.GetItems<T>(choices, length);
+    /// <inheritdoc/>
+    public T[] GetItems<T>(T[] choices, int length)
+    {
+        lock (_lock)
+        {
+            return _random.GetItems<T>(choices, length);
+        }
+    }
 
-    public T[] GetItems<T>(ReadOnlySpan<T> choices, int length) => _random.GetItems<T>(choices, length);
+    /// <inheritdoc/>
+    public T[] GetItems<T>(ReadOnlySpan<T> choices, int length)
+    {
+        lock (_lock)
+        {
+            return _random.GetItems<T>(choices, length);
+        }
+    }
 
-    public string GetString(ReadOnlySpan<char> choices, int length) => _random.GetString(choices, length);
+    /// <inheritdoc/>
+    public string GetString(ReadOnlySpan<char> choices, int length)
+    {
+        lock (_lock)
+        {
+            return _random.GetString(choices, length);
+        }
+    }
 
-    public int Next() => _random.Next();
+    /// <inheritdoc/>
+    public int Next()
+    {
+        lock (_lock)
+        {
+            return _random.Next();
+        }
+    }
 
-    public int Next(int maxValue) => _random.Next(maxValue);
+    /// <inheritdoc/>
+    public int Next(int maxValue)
+    {
+        lock (_lock)
+        {
+            return _random.Next(maxValue);
+        }
+    }
 
-    public int Next(int minValue, int maxValue) => _random.Next(minValue, maxValue);
+    /// <inheritdoc/>
+    public int Next(int minValue, int maxValue)
+    {
+        lock (_lock)
+        {
+            return _random.Next(minValue, maxValue);
+        }
+    }
 
-    public void NextBytes(byte[] buffer) => _random.NextBytes(buffer);
+    /// <inheritdoc/>
+    public void NextBytes(byte[] buffer)
+    {
+        lock (_lock)
+        {
+            _random.NextBytes(buffer);
+        }
+    }
 
-    public void NextBytes(Span<byte> buffer) => _random.NextBytes(buffer);
+    /// <inheritdoc/>
+    public void NextBytes(Span<byte> buffer)
+    {
+        lock (_lock)
+        {
+            _random.NextBytes(buffer);
+        }
+    }
 
-    public double NextDouble() => _random.NextDouble();
+    /// <inheritdoc/>
+    public double NextDouble()
+    {
+        lock (_lock)
+        {
+            return _random.NextDouble();
+        }
+    }
 
-    public long NextInt64() => _random.NextInt64();
+    /// <inheritdoc/>
+    public long NextInt64()
+    {
+        lock (_lock)
+        {
+            return _random.NextInt64();
+        }
+    }
 
-    public long NextInt64(long maxValue) => _random.NextInt64(maxValue);
+    /// <inheritdoc/>
+    public long NextInt64(long maxValue)
+    {
+        lock (_lock)
+        {
+            return _random.NextInt64(maxValue);
+        }
+    }
 
-    public long NextInt64(long minValue, long maxValue) => _random.NextInt64(minValue, maxValue);
+    /// <inheritdoc/>
+    public long NextInt64(long minValue, long maxValue)
+    {
+        lock (_lock)
+        {
+            return _random.NextInt64(minValue, maxValue);
+        }
+    }
 
-    public float NextSingle() => _random.NextSingle();
+    /// <inheritdoc/>
+    public float NextSingle()
+    {
+        lock (_lock)
+        {
+            return _random.NextSingle();
+        }
+    }
 
-    public void Shuffle<T>(T[] values) => _random.Shuffle<T>(values);
+    /// <inheritdoc/>
+    public void Shuffle<T>(T[] values)
+    {
+        lock (_lock)
+        {
+            _random.Shuffle<T>(values);
+        }
+    }
 
-    public void Shuffle<T>(Span<T> values) => _random.Shuffle<T>(values);
+    /// <inheritdoc/>
+    public void Shuffle<T>(Span<T> values)
+    {
+        lock (_lock)
+        {
+            _random.Shuffle<T>(values);
+        }
+    }
 }


### PR DESCRIPTION
Refactor RNG module to register a single thread-safe implementation, but with manual instantiation available.

The single registered instance should be able to be optionaly configured with a seed.